### PR TITLE
Ingress busines

### DIFF
--- a/k8s/workloads/refractr/refractr-ingress.yaml
+++ b/k8s/workloads/refractr/refractr-ingress.yaml
@@ -15,8 +15,8 @@ metadata:
 spec:
   releaseName: refractr-nginx-ingress
   chart:
-    repository: https://kubernetes-charts.storage.googleapis.com
-    name: nginx-ingress
+    repository: https://kubernetes.github.io/ingress-nginx
+    name: ingress-nginx
     version: "2.16.0"
   values:
     controller:

--- a/k8s/workloads/refractr/refractr-ingress.yaml
+++ b/k8s/workloads/refractr/refractr-ingress.yaml
@@ -8,12 +8,12 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: nginx-ingress
+  name: ingress-nginx
   namespace: refractr-stage
   labels:
     app: refractr
 spec:
-  releaseName: refractr-nginx-ingress
+  releaseName: refractr-ingress-nginx
   chart:
     repository: https://kubernetes.github.io/ingress-nginx
     name: ingress-nginx


### PR DESCRIPTION
Switches from using `stable/nginx-ingress` to `ingress-nginx/ingress-nginx` the former package has been consider DEPRECATED so lets move over to something that is maintained