### PR TITLE
update tf modules pinned for updates in terraform-modules

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -23,10 +23,11 @@ locals {
 
   node_groups = {
     default_node_group = {
+      name             = "itse-apps-stage-1-default_node_group-fluent-tahr"
       desired_capacity = 3,
       min_capacity     = 3,
       max_capacity     = 10,
-      instance_type    = "t3.large",
+      instance_types   = ["t3.large"],
       disk_size        = 100,
       subnets          = data.terraform_remote_state.vpc.outputs.public_subnets
     }
@@ -34,7 +35,7 @@ locals {
 }
 
 module "itse-apps-stage-1" {
-  source                    = "github.com/mozilla-it/terraform-modules//aws/eks?ref=master"
+  source                    = "github.com/mozilla-it/terraform-modules//aws/eks?ref=d9a7662d464cd395d87fbc26a0682a50c4fb208f"
   cluster_name              = "itse-apps-stage-1"
   cluster_version           = "1.18"
   vpc_id                    = data.terraform_remote_state.vpc.outputs.vpc_id

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -23,7 +23,11 @@ locals {
 
   node_groups = {
     default_node_group = {
-      name             = "itse-apps-stage-1-default_node_group-fluent-tahr"
+      # name explicitly specified only to handle upstream EKS changes: 
+      # https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/upgrades.md#upgrade-module-to-v1700-for-managed-node-groups
+      # should probably remove name & use name_prefix next time nodegroup is upgraded:
+      # https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/modules/node_groups#node_groups-and-node_groups_defaults-keys
+      name             = "itse-apps-stage-1-default_node_group-fluent-tahr",
       desired_capacity = 3,
       min_capacity     = 3,
       max_capacity     = 10,
@@ -35,7 +39,7 @@ locals {
 }
 
 module "itse-apps-stage-1" {
-  source                    = "github.com/mozilla-it/terraform-modules//aws/eks?ref=d9a7662d464cd395d87fbc26a0682a50c4fb208f"
+  source                    = "github.com/mozilla-it/terraform-modules//aws/eks?ref=master"
   cluster_name              = "itse-apps-stage-1"
   cluster_version           = "1.18"
   vpc_id                    = data.terraform_remote_state.vpc.outputs.vpc_id

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,24 +1,22 @@
 provider "aws" {
   region  = var.region
-  version = "~> 2"
+  version = "~> 3"
 }
 
 provider "kubernetes" {
-  version                = "~> 1"
+  version                = "~> 2"
   host                   = data.aws_eks_cluster.itse-apps-stage-1.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.itse-apps-stage-1.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.itse-apps-stage-1.token
-  load_config_file       = false
 }
 
 provider "helm" {
-  version = "~> 1"
+  version = "~> 2"
 
   kubernetes {
     host                   = data.aws_eks_cluster.itse-apps-stage-1.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.itse-apps-stage-1.certificate_authority.0.data)
     token                  = data.aws_eks_cluster_auth.itse-apps-stage-1.token
-    load_config_file       = false
   }
 }
 


### PR DESCRIPTION
Jira ticket: https://jira.mozilla.com/browse/SE-1919

What this PR does:
* updates terraform module pinned versions to work with updates in [mozilla-it/terraform-modules](https://github.com/mozilla-it/terraform-modules)
~* pins our usage of eks module from [mozilla-it/terraform-modules](https://github.com/mozilla-it/terraform-modules) to a commit so can avoid upstream changes altering us~