### PR TITLE
Se 1919

### DIFF
--- a/k8s/workloads/refractr/refractr-ingress.yaml
+++ b/k8s/workloads/refractr/refractr-ingress.yaml
@@ -11,7 +11,7 @@ spec:
   chart:
     repository: https://kubernetes.github.io/ingress-nginx
     name: ingress-nginx
-    version: "3.7.1"
+    version: "3.33.0"
   values:
     controller:
       useIngressClassOnly: true

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,12 +22,7 @@ locals {
   subnet_id = [for s in data.aws_subnet.public : s.id]
 
   node_groups = {
-    default_node_group = {
-      # name explicitly specified only to handle upstream EKS changes: 
-      # https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/upgrades.md#upgrade-module-to-v1700-for-managed-node-groups
-      # should probably remove name & use name_prefix next time nodegroup is upgraded:
-      # https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/modules/node_groups#node_groups-and-node_groups_defaults-keys
-      name             = "itse-apps-stage-1-default_node_group-fluent-tahr",
+    green_node_group = {
       desired_capacity = 3,
       min_capacity     = 3,
       max_capacity     = 10,


### PR DESCRIPTION
Jira ticket: https://jira.mozilla.com/browse/SE-1919

What this PR does:
- rolled over nodegroup in itse-apps-stage-1 so updated terraform to reflect that (part of testing why NLB managed by ingress-nginx service isn't registering https targets when nodes roll over)
- updated ingress-nginx helm chart to see if upstream changes address the ingress-nginx service-managed NLB & registration of https targets after a node-group rolls over