### PR TITLE
option 2 for pastebin stage integration & structure

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -45,10 +45,10 @@ module "itse-apps-stage-1" {
   cluster_version           = "1.18"
   enable_logging            = true
   external_secrets_settings = local.external_secrets_settings
+  flux_settings             = local.flux_settings
+  node_groups               = local.node_groups
+  vpc_id                    = data.terraform_remote_state.vpc.outputs.vpc_id
   # fluentd_papertrail_settings = local.fluentd_papertrail_settings
-  flux_settings = local.flux_settings
-  node_groups   = local.node_groups
-  vpc_id        = data.terraform_remote_state.vpc.outputs.vpc_id
 }
 
 # Chicken and egg issue, this needs to exist first

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,11 +2,12 @@ output "cluster_id" {
   value = module.itse-apps-stage-1.cluster_id
 }
 
-output "cluster_oidc_issuer_url" {
-  value = module.itse-apps-stage-1.cluster_oidc_issuer_url
-}
 output "cluster_name" {
   value = module.itse-apps-stage-1.cluster_id
+}
+
+output "cluster_oidc_issuer_url" {
+  value = module.itse-apps-stage-1.cluster_oidc_issuer_url
 }
 
 output "refractr_eip_allocation_id" {

--- a/terraform/pastebin.tf
+++ b/terraform/pastebin.tf
@@ -1,0 +1,47 @@
+module "pastebin-stage-db" {
+  source = "git::https://github.com/mozilla-it/terraform-modules.git//aws/database"
+
+  identifier = "pastebin-${var.environment}"
+  name       = "pastebin"
+  storage_gb = 20
+  subnets    = data.terraform_remote_state.vpc.outputs.private_subnets
+  type       = "mysql"
+  username   = "pastebin"
+  vpc_id     = data.terraform_remote_state.vpc.outputs.vpc_id
+
+  cost_center = var.cost_center
+  environment = var.environment
+  project     = "pastebin"
+}
+
+# Pastebin Application Secrets Metadata
+
+resource "aws_secretsmanager_secret" "db_host" {
+  name        = "websre/pastebin/env/database_host"
+  description = "pastebin stage DB_HOST"
+}
+
+resource "aws_secretsmanager_secret" "db_name" {
+  name        = "websre/pastebin/env/database_name"
+  description = "pastebin stage DB_NAME"
+}
+
+resource "aws_secretsmanager_secret" "db_pass" {
+  name        = "websre/pastebin/env/database_password"
+  description = "pastebin stage DB_PASS"
+}
+
+resource "aws_secretsmanager_secret" "db_port" {
+  name        = "websre/pastebin/env/database_port"
+  description = "pastebin stage DB_PORT"
+}
+
+resource "aws_secretsmanager_secret" "db_user" {
+  name        = "websre/pastebin/env/database_user"
+  description = "pastebin stage DB_USER"
+}
+
+resource "aws_secretsmanager_secret" "session_key" {
+  name        = "websre/pastebin/env/session_key"
+  description = "pastebin stage SESSION_KEY"
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,6 +1,15 @@
 provider "aws" {
   region  = var.region
   version = "~> 3"
+
+  default_tags {
+    tags = {
+      Region      = var.region
+      Environment = var.environment
+      Terraform   = "true"
+      CostCenter  = var.cost_center
+    }
+  }
 }
 
 provider "kubernetes" {

--- a/terraform/state.tf
+++ b/terraform/state.tf
@@ -1,8 +1,4 @@
 terraform {
-  required_version = ">= 0.12"
-}
-
-terraform {
   backend "s3" {
     bucket = "itse-apps-stage-1-state"
     key    = "terraform.tfstate"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,14 @@
+variable "cost_center" {
+  default = "1410"
+  type    = string
+}
+
+variable "environment" {
+  default = "stage"
+  type    = string
+}
+
 variable "region" {
   default = "us-west-2"
+  type    = string
 }

--- a/terraform/variables.tfvars
+++ b/terraform/variables.tfvars
@@ -1,0 +1,3 @@
+cost_center = "1410"
+environment = "stage"
+region      = "us-west-2"


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-1994

notes:
* if you're too busy to review, this can sit. its just cleanup & low-hanging fruit changes while working on this. 
* it is one alternative; either we choose this route or #64 (or neither, but we don't choose both)
* #66 is independent of these options and reviewed separately;
* the workflow here: you'd change into terraform folder to manage cluster, shared infra & applications state together

What this PR does:
* adds pastebin staging infrastructure in terraform/ (e.g. RDS MySql database & some AWS secrets - metadata only, values added by operator)
* next steps: will need to ensure itse-apps-stage-1 nodegroup role can connect to the above mysql db (still investigating best way to do this within our upstream rds module)

Why this PR:
* this is not a priority, but as it was low hanging & not time-consuming fruit during the work for another topic, here it is. if nobody has time to review it, this can sit.
* adds pastebin stage infra & sets pattern for next few applications