### PR TITLE
Use AWS terraform provider default_tags to assign common_tags

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -45,10 +45,10 @@ module "itse-apps-stage-1" {
   cluster_version           = "1.18"
   enable_logging            = true
   external_secrets_settings = local.external_secrets_settings
+  flux_settings             = local.flux_settings
+  node_groups               = local.node_groups
+  vpc_id                    = data.terraform_remote_state.vpc.outputs.vpc_id
   # fluentd_papertrail_settings = local.fluentd_papertrail_settings
-  flux_settings = local.flux_settings
-  node_groups   = local.node_groups
-  vpc_id        = data.terraform_remote_state.vpc.outputs.vpc_id
 }
 
 # Chicken and egg issue, this needs to exist first

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,11 +2,12 @@ output "cluster_id" {
   value = module.itse-apps-stage-1.cluster_id
 }
 
-output "cluster_oidc_issuer_url" {
-  value = module.itse-apps-stage-1.cluster_oidc_issuer_url
-}
 output "cluster_name" {
   value = module.itse-apps-stage-1.cluster_id
+}
+
+output "cluster_oidc_issuer_url" {
+  value = module.itse-apps-stage-1.cluster_oidc_issuer_url
 }
 
 output "refractr_eip_allocation_id" {

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,6 +1,15 @@
 provider "aws" {
   region  = var.region
   version = "~> 3"
+
+  default_tags {
+    tags = {
+      Region      = var.region
+      Environment = var.environment
+      Terraform   = "true"
+      CostCenter  = var.cost_center
+    }
+  }
 }
 
 provider "kubernetes" {

--- a/terraform/state.tf
+++ b/terraform/state.tf
@@ -1,8 +1,4 @@
 terraform {
-  required_version = ">= 0.12"
-}
-
-terraform {
   backend "s3" {
     bucket = "itse-apps-stage-1-state"
     key    = "terraform.tfstate"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,14 @@
+variable "cost_center" {
+  default = "1410"
+  type    = string
+}
+
+variable "environment" {
+  default = "stage"
+  type    = string
+}
+
 variable "region" {
   default = "us-west-2"
+  type    = string
 }

--- a/terraform/variables.tfvars
+++ b/terraform/variables.tfvars
@@ -1,0 +1,3 @@
+cost_center = "1410"
+environment = "stage"
+region      = "us-west-2"


### PR DESCRIPTION
Jira: Came up in context of working on https://mozilla-hub.atlassian.net/browse/SE-1994

note: if you're too busy to review, this can sit. its just cleanup & low-hanging fruit changes while working on this. it would go before the question posed in slack & PRs about terraform structure.

What this PR does:
* changes our itse-apps-stage-1 cluster infrastructure to use the AWS terraform providers default_tags; see: https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags
* does some other cleanup (formatting, variable usage, removing duplicated terraform configurations)

Why this PR:
* this is not a priority, but as it was low hanging & not time-consuming fruit during the work for another topic, here it is. if nobody has time to review it, this can sit.
* it gets us better managing AWS resources via tagging mechanisms that, by default / without our intervention, cover all touched resources.