### PR TITLE
Attempt flux + helmrelease deploy of pastebin to stage

### DIFF
--- a/k8s/namespaces/pastebin-stage.yaml
+++ b/k8s/namespaces/pastebin-stage.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pastebin-stage

--- a/k8s/releases/pastebin/pastebin.yaml
+++ b/k8s/releases/pastebin/pastebin.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: pastebin
+  namespace: pastebin-stage
+  labels:
+    app: pastebin
+  annotations:
+    fluxcd.io/automated: "true"
+    filter.fluxcd.io/chart-image: regex:^(stg-[a-f0-9]{7})$
+spec:
+  releaseName: pastebin
+  chart:
+    repository: https://mozilla-it.github.io/helm-charts/
+    name: pastebin
+    version: "0.1.0"
+  values:
+    configMap:
+      data:
+        DB_PORT: "3306"
+        VAL: "5"
+    deployment:
+      port: "8000"
+      replicaCount: 1
+    externalSecrets:
+      enabled: true
+      name: pastebin
+      secrets:
+      - key: /stage/pastebin/envvar
+        name: DB_HOST
+        property: database_host
+      - key: /stage/pastebin/envvar
+        name: DB_NAME
+        property: database_name
+      - key: /stage/pastebin/envvar
+        name: DB_PASS
+        property: database_password
+      - key: /stage/pastebin/envvar
+        name: DB_USER
+        property: database_user
+      - key: /stage/pastebin/envvar
+        name: SESSION_KEY
+        property: session_key
+    image:
+      pullPolicy: Always
+      tag: v3.5.4
+    ingress:
+      hosts:
+        - host: paste.stage.mozit.cloud
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+              serviceName: pastebin
+              servicePort: 80
+        - host: paste.allizom.org
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+              serviceName: pastebin
+              servicePort: 80
+      name: pastebin
+      tls:
+        - hosts:
+            - paste.allizom.com
+          secretName: cert-paste-allizom-org
+        - hosts:
+            - paste.stage.mozit.cloud
+          secretName: cert-paste-stage-mozit-cloud

--- a/k8s/workloads/pastebin/pastebin-ingress.yaml
+++ b/k8s/workloads/pastebin/pastebin-ingress.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: ingress-nginx
+  namespace: pastebin-stage
+  labels:
+    app: pastebin
+spec:
+  releaseName: pastebin-ingress-nginx
+  chart:
+    repository: https://kubernetes.github.io/ingress-nginx
+    name: ingress-nginx
+    version: "3.33.0"
+  values:
+    controller:
+      useIngressClassOnly: true
+      enableCustomResources: false
+      autoscaling:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 4
+        targetCPUUtilizationPercentage: 80
+        targetMemoryUtilizationPercentage: 80
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi
+      admissionWebhooks:
+        enable: false
+      scope:
+        enabled: true
+      config:
+        use-proxy-protocol: "false"
+        use-forwarded-headers: "true"
+        # restrict this to the IP addresses of ELB
+        proxy-real-ip-cidr: "0.0.0.0/0"
+      service:
+        externalTrafficPolicy: "Local"
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+          service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+          service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
+          service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "Environment=stage"
+          external-dns.alpha.kubernetes.io/hostname: "paste.stage.mozit.cloud"
+      metrics:
+        enabled: true
+        service:
+          annotations:
+            prometheus.io/scrape: "true"
+            prometheus.io/port: "10254"
+    rbac:
+      create: true
+      scope: true


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-2103

What this PR does:
* deploy pastebin via flux + helmrelease + helm chart into stage cluster
* intention is for pastebin to redeploy to stage whenever the requisite ECR pastebin repo shows a new image with tag format of stg-{seven digit commit sha}
