### PR TITLE
Add Moderator Stage namespace, ingress-nginx deploy, helm release

### DIFF
--- a/k8s/namespaces/moderator-stage.yaml
+++ b/k8s/namespaces/moderator-stage.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: moderator-stage

--- a/k8s/releases/moderator/moderator.yaml
+++ b/k8s/releases/moderator/moderator.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: moderator
+  namespace: moderator-stage
+  labels:
+    app: moderator
+  annotations:
+    fluxcd.io/automated: "true"
+    filter.fluxcd.io/chart-image: regex:^(stg-[a-f0-9]{7})$
+spec:
+  releaseName: moderator
+  chart:
+    repository: https://mozilla-it.github.io/helm-charts/
+    name: moderator
+    version: "0.1.1"
+  values:
+    configMap:
+      data:
+        DB_PORT: "3306"
+        VAL: "5"
+    deployment:
+      port: "8000"
+      replicaCount: "1"
+    externalSecrets:
+      enabled: true
+      name: moderator
+      secrets:
+      - key: /stage/moderator/envvar
+        name: DB_HOST
+        property: database_host
+      - key: /stage/moderator/envvar
+        name: DB_NAME
+        property: database_name
+      - key: /stage/moderator/envvar
+        name: DB_PASS
+        property: database_password
+      - key: /stage/moderator/envvar
+        name: DB_USER
+        property: database_user
+      - key: /stage/moderator/envvar
+        name: SESSION_KEY
+        property: session_key
+    image:
+      pullPolicy: Always
+      tag: v3.5.4
+    ingress:
+      hosts:
+        - host: paste.stage.mozit.cloud
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+              serviceName: moderator
+              servicePort: 80
+        - host: paste.allizom.org
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+              serviceName: moderator
+              servicePort: 80
+        - host: moderator.allizom.org
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+              serviceName: moderator
+              servicePort: 80
+        - host: moderator-dev.allizom.org
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+              serviceName: moderator
+              servicePort: 80
+      le:
+        name: prod
+      name: moderator
+      tls:
+        - hosts:
+            - moderator.allizom.org
+          secretName: cert-moderator-allizom-org
+        - hosts:
+            - moderator.stage.mozit.cloud
+          secretName: cert-moderator-stage-mozit-cloud

--- a/k8s/workloads/moderator/moderator-ingress.yaml
+++ b/k8s/workloads/moderator/moderator-ingress.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: ingress-nginx
+  namespace: moderator-stage
+  labels:
+    app: moderator
+spec:
+  releaseName: moderator-ingress-nginx
+  chart:
+    repository: https://kubernetes.github.io/ingress-nginx
+    name: ingress-nginx
+    version: "3.33.0"
+  values:
+    controller:
+      useIngressClassOnly: true
+      enableCustomResources: false
+      autoscaling:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 4
+        targetCPUUtilizationPercentage: 80
+        targetMemoryUtilizationPercentage: 80
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi
+      admissionWebhooks:
+        enable: false
+      scope:
+        enabled: true
+      config:
+        use-proxy-protocol: "false"
+        use-forwarded-headers: "true"
+        # restrict this to the IP addresses of ELB
+        proxy-real-ip-cidr: "0.0.0.0/0"
+      service:
+        externalTrafficPolicy: "Local"
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+          service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+          service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
+          service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "Environment=stage"
+          external-dns.alpha.kubernetes.io/hostname: "moderator.stage.mozit.cloud,moderator.allizom.org"
+      metrics:
+        enabled: true
+        service:
+          annotations:
+            prometheus.io/scrape: "true"
+            prometheus.io/port: "10254"
+    rbac:
+      create: true
+      scope: true


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-2165

What this PR does:
* adds kubernetes namespace for moderator-stage 
* adds helmrelease for ingress-nginx for ELB management behind moderator.stage.mozit.cloud, moderator.allizom.org
* adds helmrelease for moderator stage (there will no doubt be some edits here as we change moderator to use releases for CD)

Blocked by: https://github.com/mozilla-it/helm-charts/pull/99 