### PR TITLE
some repairs to infra to get moderator helmrelease working

### DIFF
--- a/k8s/releases/moderator/moderator.yaml
+++ b/k8s/releases/moderator/moderator.yaml
@@ -22,8 +22,6 @@ spec:
         ANON_ALWAYS: true
         AWS_DEFAULT_REGION: us-west-2
         FROM_NOREPLY: Mozilla Moderator <no-reply@moderator.allizom.org>
-        MOZILLIANS_API_BASE: https://mozillians.org/api/v1/users/
-        MOZILLIANS_API_URL: https://mozillians.org/api/v2/
         OIDC_OP_AUTHORIZATION_ENDPOINT: https://auth.mozilla.auth0.com/authorize
         OIDC_OP_DOMAIN: auth.mozilla.auth0.com
         OIDC_OP_JWKS_ENDPOINT: https://auth.mozilla.auth0.com/.well-known/jwks.json

--- a/k8s/releases/moderator/moderator.yaml
+++ b/k8s/releases/moderator/moderator.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: mozmoderator
-    version: "0.2.0"
+    version: "0.2.1"
   values:
     configMap:
       data:

--- a/terraform/applications/moderator/domain.tf
+++ b/terraform/applications/moderator/domain.tf
@@ -1,15 +1,9 @@
 # moderator.stage.mozit.cloud
-# -> lb, k8s
+# -> lb, k8s via external-dns
 
 # moderator.allizom.org
-# -> email / SES setup
-# -> lb, k8s
-
-module "moderator_mozit" {
-  source       = "github.com/mozilla-it/terraform-modules//aws/dns/subdomain?ref=master"
-  domain       = var.moderator_mozit
-  apex_zone_id = data.terraform_remote_state.k8s.outputs.stage_dns_zone_id
-}
+# -> email / SES setup via terraform
+# -> lb, k8s via external-dns
 
 module "moderator_mozilla" {
   source = "github.com/mozilla-it/terraform-modules//aws/dns/apex?ref=master"

--- a/terraform/applications/moderator/state.tf
+++ b/terraform/applications/moderator/state.tf
@@ -24,13 +24,3 @@ data "terraform_remote_state" "vpc" {
     region = "eu-west-1"
   }
 }
-
-data "terraform_remote_state" "k8s" {
-  backend = "s3"
-
-  config = {
-    bucket = "itse-apps-stage-1-state"
-    key    = "terraform.tfstate"
-    region = "us-west-2"
-  }
-}

--- a/terraform/applications/moderator/variables.tf
+++ b/terraform/applications/moderator/variables.tf
@@ -13,11 +13,6 @@ variable "moderator_mozilla" {
   type    = string
 }
 
-variable "moderator_mozit" {
-  default = "moderator.stage.mozit.cloud"
-  type    = string
-}
-
 variable "mysql_instance" {
   default = "db.t3.micro"
   type    = string

--- a/terraform/applications/moderator/variables.tfvars
+++ b/terraform/applications/moderator/variables.tfvars
@@ -7,5 +7,5 @@ mysql_storage_max       = 20
 mysql_version           = "5.6"
 project                 = "moderator"
 project_desc            = "moderator.allizom.org"
-project_email           = "it-sre@allizom.com"
+project_email           = "it-sre@mozilla.com"
 region                  = "us-west-2"

--- a/terraform/applications/moderator/variables.tfvars
+++ b/terraform/applications/moderator/variables.tfvars
@@ -1,7 +1,6 @@
 cost_center             = "1410"
 environment             = "stage"
 moderator_mozilla       = "moderator.allizom.org"
-moderator_mozit         = "moderator.stage.mozit.cloud"
 mysql_instance          = "db.t3.micro"
 mysql_storage_allocated = 5
 mysql_storage_max       = 20

--- a/terraform/shared/outputs.tf
+++ b/terraform/shared/outputs.tf
@@ -17,3 +17,7 @@ output "refractr_eip_allocation_id" {
 output "refractr_ips" {
   value = aws_eip.refractr_eip.*.public_ip
 }
+
+output "stage_dns_zone_id" {
+  value = module.stage_dns_zone.zone_id
+}

--- a/terraform/shared/outputs.tf
+++ b/terraform/shared/outputs.tf
@@ -17,7 +17,3 @@ output "refractr_eip_allocation_id" {
 output "refractr_ips" {
   value = aws_eip.refractr_eip.*.public_ip
 }
-
-output "stage_dns_zone_id" {
-  value = module.stage_dns_zone.zone_id
-}


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-2165

What this PR does:
* remote moderator.stage.mozit.cloud route53 management from terraform, and instead entirely leverage external-dns (e.g. via k8s)
* update mozmoderator helmrelease to reflect helmchart with no commands arg
* remove MOZILLIANS_API_* values (see https://github.com/mozilla-it/helm-charts/pull/111)