### PR TITLE
actually restrict moderator ingress real-ip to VPC IP addresses

### DIFF
--- a/k8s/workloads/moderator/moderator-ingress.yaml
+++ b/k8s/workloads/moderator/moderator-ingress.yaml
@@ -37,7 +37,7 @@ spec:
         use-proxy-protocol: "false"
         use-forwarded-headers: "true"
         # restrict this to the IP addresses of ELB
-        proxy-real-ip-cidr: "0.0.0.0/0"
+        proxy-real-ip-cidr: "172.16.0.0/16"
       service:
         externalTrafficPolicy: "Local"
         annotations:


### PR DESCRIPTION
Jira ticket: related to https://mozilla-hub.atlassian.net/browse/SE-762

What this PR does:
- adds VPC IPv4 range to real-ip config values of moderator ingress-nginx helmrelease, to see if we can fix error @akatsoulas is finding wrt source IPs showing up in correct place in nginx logging / passed headers to moderator