### PR TITLE
remove special logging for moderator ingress nginx testing

### DIFF
--- a/k8s/workloads/moderator/moderator-ingress.yaml
+++ b/k8s/workloads/moderator/moderator-ingress.yaml
@@ -36,13 +36,6 @@ spec:
       config:
         use-proxy-protocol: "false"
         use-forwarded-headers: "true"
-        log-format-upstream: '{ "@timestamp": "$time_iso8601", "remote_addr": "$remote_addr",
-          "http_x_forward_for": "$http_x_forwarded_for", "proxy_x_forward_for": "$proxy_add_x_forwarded_for",
-          "request_id": "$request_id", "remote_user": "$remote_user", "bytes_sent": $bytes_sent,
-          "request_time": $request_time, "status": $status, "vhost": "$host",
-          "request_proto": "$server_protocol", "path": "$uri", "request_query": "$args",
-          "request_length": $request_length, "duration": $request_time, "method": "$request_method",
-          "http_referrer": "$http_referer", "http_user_agent": "$http_user_agent" }'
         # restrict this to the IP addresses of ELB
         proxy-real-ip-cidr: "172.16.0.0/16"
       service:

--- a/k8s/workloads/moderator/moderator-ingress.yaml
+++ b/k8s/workloads/moderator/moderator-ingress.yaml
@@ -34,8 +34,10 @@ spec:
       scope:
         enabled: true
       config:
-        use-proxy-protocol: "false"
+        compute-full-forwarded-for: "true"
+        enable-real-ip: "true"
         use-forwarded-headers: "true"
+        use-proxy-protocol: "false"
         # restrict this to the IP addresses of ELB
         proxy-real-ip-cidr: "172.16.0.0/16"
       service:


### PR DESCRIPTION
see #86 

Believe this is now repaired by https://github.com/mozilla/mozmoderator/pull/357
