### PR TITLE
update discourse helmreleases & application infrastructure to not expect kube2iam / use specific discourse IAM role

### DIFF
--- a/k8s/releases/discourse/discourse-dev.yaml
+++ b/k8s/releases/discourse/discourse-dev.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: discourse
-    version: "0.0.1"
+    version: "1.0.0"
   values:
     configMap:
       data:
@@ -46,8 +46,6 @@ spec:
     db:
       migrate:
         enabled: true
-    deployment:
-      arn_role: arn:aws:iam::783633885093:role/discourse/discourse-dev
     externalSecrets:
       enabled: true
       name: discourse

--- a/k8s/releases/discourse/discourse-stage.yaml
+++ b/k8s/releases/discourse/discourse-stage.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: discourse
-    version: "0.0.1"
+    version: "1.0.0"
   values:
     configMap:
       data:
@@ -46,8 +46,6 @@ spec:
     db:
       migrate:
         enabled: true
-    deployment:
-      arn_role: arn:aws:iam::783633885093:role/discourse/discourse-stage
     externalSecrets:
       enabled: true
       name: discourse


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-2169

Blocker: https://github.com/mozilla-it/helm-charts/pull/115

What this PR does:
* removes (from state; leaves for clean up after old cluster gone) discourse_role resource from discourse application infra
* gives discourse uploads bucket s3 permissions to cluster nodegroup role (to be refined later)
* Removes `deployment.arn_role` value from the Discourse application helmrelease & updates helm chart to use what is in blocker PR
* we're doing this because it expects kube2iam, which isn't a given on new EKS clusters