### PR TITLE
Ask prometheus to not scrape refractr

### DIFF
--- a/k8s/workloads/refractr/refractr-ingress.yaml
+++ b/k8s/workloads/refractr/refractr-ingress.yaml
@@ -55,7 +55,7 @@ spec:
         enabled: true
         service:
           annotations:
-            prometheus.io/scrape: "true"
+            prometheus.io/scrape: "false"
             prometheus.io/port: "10254"
     rbac:
       create: true


### PR DESCRIPTION
It seems like refractr is generating tons of high cardinality metrics
disabling scraping to keep from tipping over the prometheus instance in the cluster