### PR TITLE
Add Etherpad Deploy Setup for Stage (Kubernetes)

### DIFF
--- a/k8s/namespaces/etherpad-stage.yaml
+++ b/k8s/namespaces/etherpad-stage.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etherpad-stage

--- a/k8s/releases/etherpad/etherpad.yaml
+++ b/k8s/releases/etherpad/etherpad.yaml
@@ -12,20 +12,12 @@ metadata:
 spec:
   releaseName: etherpad
   chart:
-    git: git@github.com:mozilla-it/helm-charts
-    ref: SE-1151
-    path: charts/etherpad
-    # repository: https://mozilla-it.github.io/helm-charts/
-    # name: etherpad
-    # version: "1.0.0"
+    repository: https://mozilla-it.github.io/helm-charts/
+    name: etherpad
+    version: "1.0.0"
   values:
     configMap:
-      data:
-        DB_CHARSET: utf8mb4
-        DB_PORT: "3306"
-        DB_TYPE: mysql
-        PORT: "80"
-        TITLE: Etherpad
+      data: {}
     externalSecrets:
       enabled: true
       secrets:
@@ -53,10 +45,10 @@ spec:
     image:
       pullPolicy: Always
       repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/etherpad
-      tag: stg-8065082
+      tag: stg-9922b5f
     ingress:
       hosts:
-      - host: pad.allizom.com
+      - host: pad.allizom.org
         paths:
           - path: /
             pathType: ImplementationSpecific
@@ -73,15 +65,8 @@ spec:
         name: prod
       tls:
       - hosts:
-          - pad.allizom.com
+          - pad.allizom.org
         secretName: chart-pad-allizom-org
       - hosts:
           - pad.stage.mozit.cloud
         secretName: chart-pad-stage-mozit-cloud
-    # oidc-gateway:
-    #   configMap:
-    #     data: 
-    #       upstream: etherpad
-    #   externalSecrets:
-    #     enabled: true
-    #     secretPath: "stage/etherpad"

--- a/k8s/releases/etherpad/etherpad.yaml
+++ b/k8s/releases/etherpad/etherpad.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: etherpad
+  namespace: etherpad-stage
+  labels:
+    app: etherpad
+  annotations:
+    fluxcd.io/automated: "true"
+    filter.fluxcd.io/chart-image: regex:^(stg-[a-f0-9]{7})$
+spec:
+  releaseName: etherpad
+  chart:
+    git: git@github.com:mozilla-it/helm-charts
+    ref: SE-1151
+    path: charts/etherpad
+    # repository: https://mozilla-it.github.io/helm-charts/
+    # name: etherpad
+    # version: "1.0.0"
+  values:
+    configMap:
+      data:
+        DB_CHARSET: utf8mb4
+        DB_PORT: "3306"
+        DB_TYPE: mysql
+        PORT: "80"
+        TITLE: Etherpad
+    externalSecrets:
+      enabled: true
+      secrets:
+      - key: /stage/etherpad/envvar
+        name: ADMIN_PASSWORD
+        property: ADMIN_PASSWORD
+      - key: /stage/etherpad/envvar
+        name: DB_HOST
+        property: DB_HOST
+      - key: /stage/etherpad/envvar
+        name: DB_NAME
+        property: DB_NAME
+      - key: /stage/etherpad/envvar
+        name: DB_PASS
+        property: DB_PASS
+      - key: /stage/etherpad/envvar
+        name: DB_USER
+        property: DB_USER
+      - key: /stage/etherpad/envvar
+        name: ETHERPAD_API_KEY
+        property: ETHERPAD_API_KEY
+      - key: /stage/etherpad/envvar
+        name: ETHERPAD_SESSION_KEY
+        property: ETHERPAD_SESSION_KEY
+    image:
+      pullPolicy: Always
+      repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/etherpad
+      tag: stg-8065082
+    ingress:
+      hosts:
+      - host: pad.allizom.com
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            serviceName: oidc-gateway
+            servicePort: 80
+      - host: pad.stage.mozit.cloud
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            serviceName: oidc-gateway
+            servicePort: 80
+      le:
+        issuer_create: true
+        name: prod
+      tls:
+      - hosts:
+          - pad.allizom.com
+        secretName: chart-pad-allizom-org
+      - hosts:
+          - pad.stage.mozit.cloud
+        secretName: chart-pad-stage-mozit-cloud
+    # oidc-gateway:
+    #   configMap:
+    #     data: 
+    #       upstream: etherpad
+    #   externalSecrets:
+    #     enabled: true
+    #     secretPath: "stage/etherpad"

--- a/k8s/workloads/etherpad/etherpad-ingress.yaml
+++ b/k8s/workloads/etherpad/etherpad-ingress.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: ingress-nginx
+  namespace: etherpad-stage
+  labels:
+    app: etherpad
+spec:
+  releaseName: etherpad-ingress-nginx
+  chart:
+    repository: https://kubernetes.github.io/ingress-nginx
+    name: ingress-nginx
+    version: "3.33.0"
+  values:
+    controller:
+      useIngressClassOnly: true
+      enableCustomResources: false
+      autoscaling:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 4
+        targetCPUUtilizationPercentage: 80
+        targetMemoryUtilizationPercentage: 80
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi
+      admissionWebhooks:
+        enable: false
+      scope:
+        enabled: true
+      config:
+        compute-full-forwarded-for: "true"
+        enable-real-ip: "true"
+        use-forwarded-headers: "true"
+        use-proxy-protocol: "false"
+        # restrict this to the IP addresses of ELB
+        proxy-real-ip-cidr: "172.16.0.0/16"
+      service:
+        externalTrafficPolicy: "Local"
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+          service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+          service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
+          service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "Environment=stage"
+          external-dns.alpha.kubernetes.io/hostname: "etherpad.stage.mozit.cloud,etherpad.allizom.org"
+      metrics:
+        enabled: true
+        service:
+          annotations:
+            prometheus.io/scrape: "true"
+            prometheus.io/port: "10254"
+    rbac:
+      create: true
+      scope: true

--- a/k8s/workloads/etherpad/etherpad-ingress.yaml
+++ b/k8s/workloads/etherpad/etherpad-ingress.yaml
@@ -47,7 +47,7 @@ spec:
           service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
           service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
           service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "Environment=stage"
-          external-dns.alpha.kubernetes.io/hostname: "etherpad.stage.mozit.cloud,etherpad.allizom.org"
+          external-dns.alpha.kubernetes.io/hostname: "pad.stage.mozit.cloud,pad.allizom.org"
       metrics:
         enabled: true
         service:

--- a/k8s/workloads/etherpad/etherpad-oidc.yaml
+++ b/k8s/workloads/etherpad/etherpad-oidc.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: etherpad-oidc-gateway
+  namespace: etherpad-stage
+  labels:
+    app: etherpad-oidc-gateway
+spec:
+  releaseName: etherpad-oidc-gateway
+  chart:
+    git: git@github.com:mozilla-it/helm-charts
+    ref: SE-1151
+    path: charts/oidc-gateway
+    # repository: https://mozilla-it.github.io/helm-charts/
+    # name: oidc-gateway
+    # version: "1.0.0"
+  values:
+    configMap:
+      data: 
+        upstream: etherpad
+    externalSecrets:
+      enabled: true
+      secretPath: "stage/etherpad"

--- a/k8s/workloads/etherpad/etherpad-oidc.yaml
+++ b/k8s/workloads/etherpad/etherpad-oidc.yaml
@@ -9,15 +9,14 @@ metadata:
 spec:
   releaseName: etherpad-oidc-gateway
   chart:
-    git: git@github.com:mozilla-it/helm-charts
-    ref: SE-1151
-    path: charts/oidc-gateway
-    # repository: https://mozilla-it.github.io/helm-charts/
-    # name: oidc-gateway
-    # version: "1.0.0"
+    repository: https://mozilla-it.github.io/helm-charts/
+    name: oidc-gateway
+    version: "1.0.0"
   values:
     configMap:
-      data: 
+      data:
+        oidc:
+          client_id: vkT03CSjhhUsqJX1tXXtPBBoInAkPamF
         upstream: etherpad
     externalSecrets:
       enabled: true


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-1151

What this PR does:
* adds Etherpad helmrelease deploy setup
* adds Etherpad stage namespace
* adds Etherpad stage ingress-nginx release
* adds Etherpad OIDC gateway release

~Blocked by: https://github.com/mozilla-it/helm-charts/pull/116~