### PR TITLE
remove pad.allizom.org from external-dns config, just need cname for etherpad

### DIFF
--- a/k8s/workloads/etherpad/etherpad-ingress.yaml
+++ b/k8s/workloads/etherpad/etherpad-ingress.yaml
@@ -47,7 +47,7 @@ spec:
           service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
           service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
           service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "Environment=stage"
-          external-dns.alpha.kubernetes.io/hostname: "pad.stage.mozit.cloud,pad.allizom.org"
+          external-dns.alpha.kubernetes.io/hostname: "pad.stage.mozit.cloud"
       metrics:
         enabled: true
         service:


### PR DESCRIPTION
Jira: cleanup for https://mozilla-hub.atlassian.net/browse/SE-2125

What this PR does:
* removes external-dns annotation for pad.allizom.org since we don't need to delegate this domain to AWS for anything, thus just need a CNAME in Infoblox pointing to pad.stage.mozit.cloud 