### PR TITLE
Collecting a few review comments

### DIFF
--- a/terraform/applications/careers/locals.tf
+++ b/terraform/applications/careers/locals.tf
@@ -19,5 +19,5 @@ locals {
   domain_name               = "careers.stage.mozit.cloud"
   subject_alternative_names = []
   aliases                   = concat([local.domain_name], local.subject_alternative_names)
-  r53_zone                  = "Z0567090QXTU93SH7QB3" # stage.mozit.cloud
+  r53_zone_name             = "stage.mozit.cloud."
 }

--- a/terraform/applications/careers/static.tf
+++ b/terraform/applications/careers/static.tf
@@ -6,6 +6,12 @@ resource "aws_s3_bucket" "logs" {
   force_destroy = true
 }
 
+data "aws_route53_zone" "careers_domain" {
+  name = local.r53_zone_name
+}
+
+
+
 resource "aws_s3_bucket" "mozilla-careers" {
   bucket = local.bucket_name
   acl    = "log-delivery-write"
@@ -38,7 +44,7 @@ resource "aws_s3_bucket" "mozilla-careers" {
       "Resource": "arn:aws:s3:::${local.bucket_name}"
     },
     {
-      "Sid": "careersAllowIndexDotHTML",
+      "Sid": "careersAllowGetAll",
       "Effect": "Allow",
       "Principal": "*",
       "Action": "s3:GetObject",
@@ -180,7 +186,7 @@ resource "aws_lambda_function" "lambda-headers" {
 }
 
 resource "aws_route53_record" "careers-cloudfront" {
-  zone_id = local.r53_zone
+  zone_id = data.aws_route53_zone.careers_domain.id
   name    = local.domain_name
   type    = "A"
   alias {


### PR DESCRIPTION
Renaming ACL to reflect the rule
Looking up zone_id for the dns zone, so we can use a human readable name instead of a magic string