### PR TITLE
Get IAM worker role name directly from module outputs.

### DIFF
--- a/terraform/applications/discourse/iam.tf
+++ b/terraform/applications/discourse/iam.tf
@@ -1,16 +1,8 @@
 data "aws_caller_identity" "current" {}
 
-locals {
-  cluster_workers_role_name = replace(
-    data.terraform_remote_state.k8s.outputs.cluster_worker_iam_role_arn,
-    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/",
-    ""
-  )
-}
-
 resource "aws_iam_role_policy" "discourse_uploads" {
   name = "discourse-${local.workspace.environment}-uploads"
-  role = local.cluster_workers_role_name
+  role = data.terraform_remote_state.k8s.outputs.cluster_worker_iam_role_name
 
   policy = <<EOF
 {

--- a/terraform/shared/outputs.tf
+++ b/terraform/shared/outputs.tf
@@ -10,6 +10,10 @@ output "cluster_worker_iam_role_arn" {
   value = module.itse-apps-stage-1.worker_iam_role_arn
 }
 
+output "cluster_worker_iam_role_name" {
+  value = module.itse-apps-stage-1.worker_iam_role_name
+}
+
 output "cluster_oidc_issuer_url" {
   value = module.itse-apps-stage-1.cluster_oidc_issuer_url
 }


### PR DESCRIPTION
This is the same change I pushed to https://github.com/mozilla-it/itse-apps-prod-1-infra/pull/71.