### PR TITLE
remove hard coded old securitygroups on secwiki

### DIFF
--- a/terraform/applications/securitywiki/efs.tf
+++ b/terraform/applications/securitywiki/efs.tf
@@ -7,8 +7,6 @@ resource "aws_efs_mount_target" "securitywiki" {
   file_system_id = aws_efs_file_system.securitywiki.id
   subnet_id      = tolist(flatten([data.terraform_remote_state.vpc.outputs.private_subnets]))[count.index]
   security_groups = [
-    data.terraform_remote_state.k8s.outputs.cluster_primary_security_group_id,
-    "sg-083a35a6d382d52dc", # old cluster
-    "sg-0b9bcd2ae46fe0792"  # old cluster
+    data.terraform_remote_state.k8s.outputs.cluster_primary_security_group_id
   ]
 }


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-2163

What this PR does:
* removes old, hard-coded security groups from securitywiki EFS mount