### PR TITLE
update discourse dev, stage to use latest helm chart with logger config as secret

### DIFF
--- a/k8s/releases/discourse/discourse-dev.yaml
+++ b/k8s/releases/discourse/discourse-dev.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: discourse
-    version: "1.0.0"
+    version: "2.0.0"
   values:
     configMap:
       data:
@@ -48,6 +48,7 @@ spec:
         enabled: true
     externalSecrets:
       enabled: true
+      loggerSecretKey: /dev/discourse/logger
       name: discourse
       secrets:
       - key: /dev/discourse/envvar

--- a/k8s/releases/discourse/discourse-stage.yaml
+++ b/k8s/releases/discourse/discourse-stage.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: discourse
-    version: "1.0.0"
+    version: "2.0.0"
   values:
     configMap:
       data:
@@ -48,6 +48,7 @@ spec:
         enabled: true
     externalSecrets:
       enabled: true
+      loggerSecretKey: /stage/discourse/logger
       name: discourse
       secrets:
       - key: /stage/discourse/envvar

--- a/terraform/applications/discourse/secrets.tf
+++ b/terraform/applications/discourse/secrets.tf
@@ -4,3 +4,9 @@ resource "aws_secretsmanager_secret" "envvar" {
   name        = "/${local.workspace.environment}/discourse/envvar"
   description = "discourse ${local.workspace.environment} environment variables as json (see helm chart for expected json)"
 }
+
+
+resource "aws_secretsmanager_secret" "logger" {
+  name        = "/${local.workspace.environment}/discourse/logger"
+  description = "discourse ${local.workspace.environment} papertrail logger configuration as json (see helm chart for expected json)"
+}


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-2173 

What this PR does:
* replaces the hard-coded logger config ConfigMap template with an ExternalSecrets setup (update discourse helm chart, add secret metadata to terraform for discourse dev, stage logger secret)
* came up in decommissioning https://github.com/mozilla-it/discourse-infra

Related to: https://github.com/mozilla-it/helm-charts/pull/121