### PR TITLE
uptick helm chart version due to key-value inversion

### DIFF
--- a/k8s/releases/discourse/discourse-dev.yaml
+++ b/k8s/releases/discourse/discourse-dev.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: discourse
-    version: "2.0.0"
+    version: "2.0.1"
   values:
     configMap:
       data:

--- a/k8s/releases/discourse/discourse-stage.yaml
+++ b/k8s/releases/discourse/discourse-stage.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: discourse
-    version: "2.0.0"
+    version: "2.0.1"
   values:
     configMap:
       data:


### PR DESCRIPTION
See https://github.com/mozilla-it/helm-charts/pull/122 - I just inverted key & name in the externalsecrets spec. Caught it in dev & stage testing first, so need to fix here too.