### PR TITLE
chore: Update chart version for discourse, etherpad, pastebin, refractr

### DIFF
--- a/k8s/releases/discourse/discourse-dev.yaml
+++ b/k8s/releases/discourse/discourse-dev.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: discourse
-    version: "2.0.2"
+    version: "2.0.3"
   values:
     configMap:
       data:

--- a/k8s/releases/discourse/discourse-stage.yaml
+++ b/k8s/releases/discourse/discourse-stage.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: discourse
-    version: "2.0.2"
+    version: "2.0.3"
   values:
     configMap:
       data:

--- a/k8s/releases/etherpad/etherpad.yaml
+++ b/k8s/releases/etherpad/etherpad.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: etherpad
-    version: "1.0.0"
+    version: "1.0.2"
   values:
     configMap:
       data: {}

--- a/k8s/releases/pastebin/pastebin.yaml
+++ b/k8s/releases/pastebin/pastebin.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: pastebin
-    version: "0.1.1"
+    version: "0.1.4"
   values:
     configMap:
       data:

--- a/k8s/releases/refractr/refractr.yaml
+++ b/k8s/releases/refractr/refractr.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: refractr
-    version: "1.0.25"
+    version: "1.1.1"
   values:
     hpa:
       enabled: true


### PR DESCRIPTION
[SE-3220](https://mozilla-hub.atlassian.net/browse/SE-3220)
Add PodDisruptionBudget apps on k8s to be upgraded.
apps: discourse, etherpad, pastebin, refractr