### PR TITLE
Update ingress configs for discourse, etherpad, moderator, pastebin

### DIFF
--- a/k8s/releases/discourse/discourse-dev.yaml
+++ b/k8s/releases/discourse/discourse-dev.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: discourse
-    version: "2.0.3"
+    version: "2.0.5"
   values:
     configMap:
       data:
@@ -95,6 +95,7 @@ spec:
       repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/discourse
       tag: dev-0bb38f7
     ingress:
+      className: ingress-nginx-discourse-dev
       annotations:
         nginx.ingress.kubernetes.io/server-snippet: |
               location /webhooks/aws {

--- a/k8s/releases/discourse/discourse-stage.yaml
+++ b/k8s/releases/discourse/discourse-stage.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: discourse
-    version: "2.0.3"
+    version: "2.0.5"
   values:
     configMap:
       data:
@@ -95,6 +95,7 @@ spec:
       repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/discourse
       tag: stage-0bb38f7
     ingress:
+      className: ingress-nginx-discourse-stage
       annotations:
         nginx.ingress.kubernetes.io/server-snippet: |
               location /webhooks/aws {

--- a/k8s/releases/etherpad/etherpad.yaml
+++ b/k8s/releases/etherpad/etherpad.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: etherpad
-    version: "1.0.2"
+    version: "1.0.3"
   values:
     configMap:
       data: {}
@@ -47,6 +47,7 @@ spec:
       repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/etherpad
       tag: stg-724a722
     ingress:
+      className: ingress-nginx-etherpad-stage
       hosts:
       - host: pad.allizom.org
         paths:

--- a/k8s/releases/moderator/moderator.yaml
+++ b/k8s/releases/moderator/moderator.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: mozmoderator
-    version: "0.2.3"
+    version: "0.2.4"
   values:
     configMap:
       data:
@@ -63,6 +63,7 @@ spec:
       repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/moderator
       tag: stg-c49289e
     ingress:
+      className: ingress-nginx-moderator-stage
       hosts:
       - host: moderator.stage.mozit.cloud
         paths:

--- a/k8s/releases/pastebin/pastebin.yaml
+++ b/k8s/releases/pastebin/pastebin.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: pastebin
-    version: "0.1.4"
+    version: "0.1.5"
   values:
     configMap:
       data:
@@ -48,6 +48,7 @@ spec:
       repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/pastebin
       tag: stg-bfb5015
     ingress:
+      className: ingress-nginx-pastebin-stage
       hosts:
       - host: paste.stage.mozit.cloud
         paths:

--- a/k8s/workloads/discourse/discourse-ingress-dev.yaml
+++ b/k8s/workloads/discourse/discourse-ingress-dev.yaml
@@ -12,10 +12,14 @@ spec:
   chart:
     repository: https://kubernetes.github.io/ingress-nginx
     name: ingress-nginx
-    version: "3.33.0"
+    version: "4.2.0"
   values:
     controller:
-      useIngressClassOnly: true
+      ingressClassResource:
+        name: ingress-nginx-discourse-dev
+        enabled: true
+        default: false
+        controllerValue: "k8s.io/ingress-nginx-discourse-dev"
       enableCustomResources: false
       autoscaling:
         enabled: true

--- a/k8s/workloads/discourse/discourse-ingress-stage.yaml
+++ b/k8s/workloads/discourse/discourse-ingress-stage.yaml
@@ -12,10 +12,14 @@ spec:
   chart:
     repository: https://kubernetes.github.io/ingress-nginx
     name: ingress-nginx
-    version: "3.33.0"
+    version: "4.2.0"
   values:
     controller:
-      useIngressClassOnly: true
+      ingressClassResource:
+        name: ingress-nginx-discourse-stage
+        enabled: true
+        default: false
+        controllerValue: "k8s.io/ingress-nginx-discourse-stage"
       enableCustomResources: false
       autoscaling:
         enabled: true

--- a/k8s/workloads/etherpad/etherpad-ingress.yaml
+++ b/k8s/workloads/etherpad/etherpad-ingress.yaml
@@ -11,10 +11,14 @@ spec:
   chart:
     repository: https://kubernetes.github.io/ingress-nginx
     name: ingress-nginx
-    version: "3.33.0"
+    version: "4.2.0"
   values:
     controller:
-      useIngressClassOnly: true
+      ingressClassResource:
+        name: ingress-nginx-etherpad-stage
+        enabled: true
+        default: false
+        controllerValue: "k8s.io/ingress-nginx-etherpad-stage"
       enableCustomResources: false
       autoscaling:
         enabled: true

--- a/k8s/workloads/moderator/moderator-ingress.yaml
+++ b/k8s/workloads/moderator/moderator-ingress.yaml
@@ -11,14 +11,18 @@ spec:
   chart:
     repository: https://kubernetes.github.io/ingress-nginx
     name: ingress-nginx
-    version: "3.33.0"
+    version: "4.2.0"
   values:
     controller:
-      useIngressClassOnly: true
+      ingressClassResource:
+        name: ingress-nginx-moderator-stage
+        enabled: true
+        default: false
+        controllerValue: "k8s.io/ingress-nginx-moderator-stage"
       enableCustomResources: false
       autoscaling:
         enabled: true
-        minReplicas: 1
+        minReplicas: 2
         maxReplicas: 4
         targetCPUUtilizationPercentage: 80
         targetMemoryUtilizationPercentage: 80

--- a/k8s/workloads/pastebin/pastebin-ingress.yaml
+++ b/k8s/workloads/pastebin/pastebin-ingress.yaml
@@ -11,10 +11,14 @@ spec:
   chart:
     repository: https://kubernetes.github.io/ingress-nginx
     name: ingress-nginx
-    version: "3.33.0"
+    version: "4.2.0"
   values:
     controller:
-      useIngressClassOnly: true
+      ingressClassResource:
+        name: ingress-nginx-pastebin-stage
+        enabled: true
+        default: false
+        controllerValue: "k8s.io/ingress-nginx-pastebin-stage"
       enableCustomResources: false
       autoscaling:
         enabled: true

--- a/k8s/workloads/refractr/refractr-ingress.yaml
+++ b/k8s/workloads/refractr/refractr-ingress.yaml
@@ -11,10 +11,14 @@ spec:
   chart:
     repository: https://kubernetes.github.io/ingress-nginx
     name: ingress-nginx
-    version: "3.33.0"
+    version: "4.2.0"
   values:
     controller:
-      useIngressClassOnly: true
+      ingressClassResource:
+        name: ingress-nginx-refractr-stage
+        enabled: true
+        default: false
+        controllerValue: "k8s.io/ingress-nginx-refractr-stage"
       enableCustomResources: false
       autoscaling:
         enabled: true


### PR DESCRIPTION
These changes do the following:
- Setup ingress class configurations per app.
- Update `nginx-ingress` version to 4.2.0
- Adjust `nginx-ingress` to use its app ingress class.
