### PR TITLE
Add Flux 2 image policy for refractr.

### DIFF
--- a/flux/images/refractr/refractr-image.yaml
+++ b/flux/images/refractr/refractr-image.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: refractr
+  namespace: flux-system
+spec:
+  image: 783633885093.dkr.ecr.us-west-2.amazonaws.com/refractr
+  interval: 5m0s
+  secretRef:
+    name: ecr-credentials

--- a/flux/images/refractr/refractr-policy.yaml
+++ b/flux/images/refractr/refractr-policy.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: moderator
+  namespace: flux-system
+spec:
+  filterTags:
+    extract: $version
+    pattern: ^v(?P<version>\d+\.\d+\.\d+-\d+)-g.*$
+  imageRepositoryRef:
+    name: moderator
+  policy:
+    semver:
+      range: ">=0.0.0-0"


### PR DESCRIPTION
Refractr uses the output of `git describe` to tag images. Stage images have tags of the form `v0.0.126-3-g1234567`. We extract the part between the initial `v` and the `-g...` suffix, and sort that part using semver.